### PR TITLE
rename options_with_instance_id to options_with_gce_instance_id preve…

### DIFF
--- a/lib/cap-gce/capistrano.rb
+++ b/lib/cap-gce/capistrano.rb
@@ -21,7 +21,7 @@ module Capistrano
       def gce_role(name, options = {})
         gce_handler.get_servers_for_role(name).each do |server|
           env.role(name, CapGCE::Utils.contact_point(server),
-                   options_with_instance_id(options, server))
+                   options_with_gce_instance_id(options, server))
         end
       end
 
@@ -31,13 +31,13 @@ module Capistrano
 
       private
 
-      def options_with_instance_id(options, server)
+      def options_with_gce_instance_id(options, server)
         options.merge(instance_id: server.id)
       end
     end
   end
 end
 
-extend Capistrano::DSL::Gce
+self.extend Capistrano::DSL::Gce
 
 Capistrano::Configuration::Server.send(:include, CapGCE::Utils::Server)

--- a/lib/cap-gce/version.rb
+++ b/lib/cap-gce/version.rb
@@ -1,3 +1,3 @@
 module CapGCE
-  VERSION = '1.1.3'.freeze
+  VERSION = '1.1.4'.freeze
 end


### PR DESCRIPTION
…nt conflict with cap-ec2